### PR TITLE
Update ToastPromptsHostControl (WP)

### DIFF
--- a/Toasts.Forms.Plugin.WindowsPhone/ToastPromtsHostControl.cs
+++ b/Toasts.Forms.Plugin.WindowsPhone/ToastPromtsHostControl.cs
@@ -139,7 +139,7 @@ namespace Plugin.Toasts
             var layoutGrid = new Grid();
             var toastItem = new ToastItem(layoutGrid, DateTime.Now, notification);
             layoutGrid.HorizontalAlignment = HorizontalAlignment.Stretch;
-            layoutGrid.Height = 70;
+            //layoutGrid.Height = 70;
             layoutGrid.Margin = new Thickness(0, 0, 0, 2); //2 - a margin between toasts
             layoutGrid.Background = notification.Brush;
             layoutGrid.Projection = new PlaneProjection();


### PR DESCRIPTION
On Windows Phone platform Toast's Height is static (hard defined) which make it hide long descriptions (toast descriptions on multiple lines etc...).
Changing this behavior to make the height of raised Toast dynamic to the toast description.
